### PR TITLE
Fix email recipient address

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ app.post("/bobai/sendmail", async (req, res) => {
 
     let mailOptions = await {
       from: "Mr Bobai <joelisaiahbobai@gmail.com>",
-      to: ["joelisaiahbobai@gmail.com>", "joelbobai43@gmail.com"],
+      to: ["joelisaiahbobai@gmail.com", "joelbobai43@gmail.com"],
       subject: `Message from ${
         name[0].toUpperCase() + name.slice(1)
       } : ${subject}`,


### PR DESCRIPTION
## Summary
- remove stray `>` from primary recipient in `mailOptions.to`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890eb6970d0832d90aa3215cc64e6ed