### PR TITLE
docs: document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DM Me
+
+A simple Express server for sending emails via Gmail.
+
+## Environment Variables
+
+The application uses the following environment variables:
+
+- `AUTH_EMAIL` – Gmail address used to authenticate the mail transporter.
+- `AUTH_PASS` – Password or app password for the above Gmail account.
+- `PORT` – _(Optional)_ Port for the server to listen on. Defaults to `6001`.
+
+### Sample `.env`
+
+```env
+AUTH_EMAIL=your-email@gmail.com
+AUTH_PASS=your-app-password
+PORT=6001
+```
+
+## Usage
+
+1. Create a `.env` file based on the variables above.
+2. Install dependencies with `npm install`.
+3. Start the server with `npm start`.


### PR DESCRIPTION
## Summary
- document required AUTH_EMAIL, AUTH_PASS and optional PORT
- add sample `.env` snippet and usage notes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890ef5a3ea4832daca3b4caba0336a9